### PR TITLE
docs: fix nonexistent search param in list table

### DIFF
--- a/examples/managing_tables.ipynb
+++ b/examples/managing_tables.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can get the list of stored tables using the ThanoSQL library. The `list()` function can be used without any parameters or with optional parameters. To list only tables which name contains some keyword(s), use the `search` parameter. You can also set the `offset` and `limit` of the results."
+    "You can get the list of stored tables using the ThanoSQL library. The `list()` function can be used without any parameters or with optional parameters. By default, all tables from all schemas will be listed. To list only tables in a certain schema, use the `schema` parameter. You can also set the `offset` and `limit` of the results."
    ]
   },
   {
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tables = client.table.list(search=\"search_keyword\", offset=1, limit=10)\n",
+    "tables = client.table.list(schema=\"public\", offset=1, limit=10)\n",
     "for table in tables:\n",
     "    print(table.name, table.table_schema)"
    ]


### PR DESCRIPTION
Fix the use of nonexistent "search" parameter in list table --> should have been "schema"