### PR TITLE
feat: rearrange parameter order and add checks for query.execute()

### DIFF
--- a/thanosql/resources/_query.py
+++ b/thanosql/resources/_query.py
@@ -35,8 +35,8 @@ class QueryService(ThanoSQLService):
 
     def execute(
         self,
-        query_type: str = "thanosql",
         query: Optional[str] = None,
+        query_type: str = "thanosql",
         template_id: Optional[int] = None,
         template_name: Optional[str] = None,
         parameters: Optional[dict] = None,

--- a/thanosql/resources/_query.py
+++ b/thanosql/resources/_query.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import enum
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from pydantic import BaseModel, TypeAdapter
 
+from thanosql._error import ThanoSQLValueError
 from thanosql._service import ThanoSQLService
 
 if TYPE_CHECKING:
@@ -26,6 +28,11 @@ class QueryLog(BaseModel):
     records: Optional[list] = None
 
 
+class QueryType(enum.Enum):
+    THANOSQL = "thanosql"
+    PSQL = "psql"
+
+
 class QueryService(ThanoSQLService):
     def __init__(self, client: ThanoSQL) -> None:
         super().__init__(client=client, tag="query")
@@ -45,6 +52,11 @@ class QueryService(ThanoSQLService):
         overwrite: Optional[bool] = None,
         max_results: Optional[int] = None,
     ) -> Union[QueryLog, dict]:
+        try:
+            query_type_enum = QueryType(query_type)
+        except Exception as e:
+            raise ThanoSQLValueError(str(e))
+        
         path = f"/{self.tag}/"
         query_params = self._create_input_dict(
             schema=schema,
@@ -53,7 +65,7 @@ class QueryService(ThanoSQLService):
             max_results=max_results,
         )
         payload = self._create_input_dict(
-            query_type=query_type,
+            query_type=query_type_enum.value,
             query_string=query,
             template_id=template_id,
             template_name=template_name,


### PR DESCRIPTION
Clickup Task ID: CU-86enzxmb9 and CU-86enzxmen

**Before:**
- We have to use `client.query.execute(query="my-query-here")`  every time
- There are no checks for the validity of query_type from the SDK side


**After:**
- We can directly do `client.query.execute("my-query-here")`
- An error will be immediately thrown if query_type is neither "psql" nor "thanosql"