### PR TITLE
fix: file upload with subdirectories

### DIFF
--- a/thanosql/_base_client.py
+++ b/thanosql/_base_client.py
@@ -63,7 +63,9 @@ class ThanoSQLBaseClient:
 
         try:
             if file:
-                payload_json["files"] = {"file": (file, open(file, "rb"))}
+                payload_json["files"] = {
+                    "file": (os.path.basename(file), open(file, "rb"))
+                }
                 if payload:
                     payload_json["files"]["body"] = (
                         None,


### PR DESCRIPTION
Previously, we cannot upload files in subdirectories. Only files directly in the same directory can be uploaded without error.

![image](https://github.com/smartmind-team/thanosql-sdk-python/assets/56180830/9870adb5-eb74-484f-bb10-bdd9e4710385)

This is because of an error in the name of the uploaded file, wherein the full (original) path is passed instead of the base filename only.
