### PR TITLE
feat: beautify basemodel repr

### DIFF
--- a/thanosql/resources/_model.py
+++ b/thanosql/resources/_model.py
@@ -1,0 +1,10 @@
+import pydantic
+
+from thanosql._service import ThanoSQLService
+
+
+class BaseModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True, json_encoders={ThanoSQLService: lambda v: str(v)})
+    
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.model_dump_json(indent=4)})"

--- a/thanosql/resources/_query.py
+++ b/thanosql/resources/_query.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import BaseModel, TypeAdapter
+from pydantic import TypeAdapter
 
 from thanosql._service import ThanoSQLService
+from thanosql.resources._model import BaseModel
 
 if TYPE_CHECKING:
     from thanosql._client import ThanoSQL

--- a/thanosql/resources/_table.py
+++ b/thanosql/resources/_table.py
@@ -5,10 +5,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import Field, TypeAdapter
 
 from thanosql._error import ThanoSQLValueError
 from thanosql._service import ThanoSQLService
+from thanosql.resources._model import BaseModel
 
 if TYPE_CHECKING:
     from thanosql._client import ThanoSQL
@@ -89,9 +90,7 @@ class TableService(ThanoSQLService):
 
         if "tables" in raw_response:
             tables_adapter = TypeAdapter(List[BaseTable])
-            parsed_response = tables_adapter.validate_python(
-                raw_response["tables"]
-            )
+            parsed_response = tables_adapter.validate_python(raw_response["tables"])
             return parsed_response
 
         return raw_response
@@ -106,9 +105,7 @@ class TableService(ThanoSQLService):
 
         if "table" in raw_response:
             table_adapter = TypeAdapter(Table)
-            parsed_response = table_adapter.validate_python(
-                raw_response["table"]
-            )
+            parsed_response = table_adapter.validate_python(raw_response["table"])
             parsed_response.service = self
             return parsed_response
 
@@ -238,9 +235,7 @@ class TableTemplateService(ThanoSQLService):
             parsed_response = {}
             parsed_response[
                 "table_templates"
-            ] = table_templates_adapter.validate_python(
-                raw_response["table_templates"]
-            )
+            ] = table_templates_adapter.validate_python(raw_response["table_templates"])
             parsed_response["versions"] = raw_response["versions"]
             return parsed_response
 
@@ -272,8 +267,6 @@ class TableTemplateService(ThanoSQLService):
 
 
 class Table(BaseTable):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     service: Optional[TableService] = None
 
     def get_records(

--- a/thanosql/resources/_view.py
+++ b/thanosql/resources/_view.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import Field, TypeAdapter
 
 from thanosql._service import ThanoSQLService
 from thanosql.resources import Column
+from thanosql.resources._model import BaseModel
 
 if TYPE_CHECKING:
     from thanosql._client import ThanoSQL
@@ -43,9 +44,7 @@ class ViewService(ThanoSQLService):
 
         if "views" in raw_response:
             views_adapter = TypeAdapter(List[View])
-            parsed_response = views_adapter.validate_python(
-                raw_response["views"]
-            )
+            parsed_response = views_adapter.validate_python(raw_response["views"])
             return parsed_response
 
         return raw_response


### PR DESCRIPTION
Clickup Task ID: CU-86enzxhjz

Beautify model representation with appropriate whitespaces.

CAVEAT: only applies to representation, i.e.

```python
res = ...
res
```

or

```python
print(repr(res))
```

does not apply to `__str__`, e.g. `print(res)`

First example is using repr, second example using str:
![image](https://github.com/smartmind-team/thanosql-sdk-python/assets/56180830/d3b040d0-0f26-457d-8105-57832c7d8d2f)
