### PR TITLE
fix: change output to match engine update

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -192,7 +192,9 @@ def test_upload_table_invalid(client: ThanoSQL, new_schema: str):
 
 
 def test_upload_table_csv(client: ThanoSQL, basic_table_name: str):
-    res = client.table.upload(name=basic_table_name, file="file_csv.csv", if_exists="replace")
+    res = client.table.upload(
+        name=basic_table_name, file="file_csv.csv", if_exists="replace"
+    )
     assert isinstance(res, Table)
 
     # check that the table and records are indeed uploaded

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -70,7 +70,7 @@ def test_create_table_success(client: ThanoSQL, new_schema: str):
     res = client.table.create(
         name=test_table_name_old, schema=new_schema, table=TableObject()
     )
-    assert isinstance(res, BaseTable)
+    assert isinstance(res, Table)
     assert res.name == test_table_name_old
 
     # check that the table is indeed created
@@ -90,7 +90,7 @@ def test_get_tables_with_options(client: ThanoSQL, new_schema: str):
     assert isinstance(res, list)
     # we only have one table in this schema
     assert len(res) == 1
-    assert isinstance(res[0], BaseTable)
+    assert isinstance(res[0], Table)
 
 
 def test_update_table(client: ThanoSQL, new_schema: str):
@@ -107,7 +107,7 @@ def test_update_table(client: ThanoSQL, new_schema: str):
     res = client.table.update(
         name=test_table_name_old, schema=new_schema, table=table_object
     )
-    assert isinstance(res, BaseTable)
+    assert isinstance(res, Table)
     assert res.name == test_table_name_old
 
     # make sure the old table is no longer retrievable
@@ -193,7 +193,7 @@ def test_upload_table_invalid(client: ThanoSQL, new_schema: str):
 
 def test_upload_table_csv(client: ThanoSQL, basic_table_name: str):
     res = client.table.upload(name=basic_table_name, file="file_csv.csv", if_exists="replace")
-    assert isinstance(res, BaseTable)
+    assert isinstance(res, Table)
 
     # check that the table and records are indeed uploaded
     target_table = client.table.get(name=basic_table_name)
@@ -221,7 +221,7 @@ def test_upload_table_excel(client: ThanoSQL, new_schema: str):
         schema=new_schema,
         table=table_object,
     )
-    assert isinstance(res, BaseTable)
+    assert isinstance(res, Table)
 
     # check that the table and records are indeed uploaded
     target_table = client.table.get(name=test_table_name_excel, schema=new_schema)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -70,8 +70,8 @@ def test_create_table_success(client: ThanoSQL, new_schema: str):
     res = client.table.create(
         name=test_table_name_old, schema=new_schema, table=TableObject()
     )
-    assert {"message", "table_name"} == set(res.keys())
-    assert res["table_name"] == test_table_name_old
+    assert isinstance(res, BaseTable)
+    assert res.name == test_table_name_old
 
     # check that the table is indeed created
     res = client.table.get(name=test_table_name_old, schema=new_schema)
@@ -107,8 +107,8 @@ def test_update_table(client: ThanoSQL, new_schema: str):
     res = client.table.update(
         name=test_table_name_old, schema=new_schema, table=table_object
     )
-    assert {"message", "table_name"} == set(res.keys())
-    assert res["table_name"] == test_table_name_old
+    assert isinstance(res, BaseTable)
+    assert res.name == test_table_name_old
 
     # make sure the old table is no longer retrievable
     with pytest.raises(ThanoSQLNotFoundError):
@@ -192,7 +192,8 @@ def test_upload_table_invalid(client: ThanoSQL, new_schema: str):
 
 
 def test_upload_table_csv(client: ThanoSQL, basic_table_name: str):
-    client.table.upload(name=basic_table_name, file="file_csv.csv", if_exists="replace")
+    res = client.table.upload(name=basic_table_name, file="file_csv.csv", if_exists="replace")
+    assert isinstance(res, BaseTable)
 
     # check that the table and records are indeed uploaded
     target_table = client.table.get(name=basic_table_name)
@@ -214,12 +215,13 @@ def test_upload_table_excel(client: ThanoSQL, new_schema: str):
         ]
     )
 
-    client.table.upload(
+    res = client.table.upload(
         name=test_table_name_excel,
         file="file_excel.xlsx",
         schema=new_schema,
         table=table_object,
     )
+    assert isinstance(res, BaseTable)
 
     # check that the table and records are indeed uploaded
     target_table = client.table.get(name=test_table_name_excel, schema=new_schema)

--- a/tests/test_table_template.py
+++ b/tests/test_table_template.py
@@ -55,7 +55,8 @@ def test_create_table_template_success(
         table_template=TableObject(),
         version=latest_version,
     )
-    assert {"message", "table_template_name"} == set(res.keys())
+    assert isinstance(res, TableTemplate)
+    assert res.name == empty_table_template_name
 
 
 def test_get_table_template_not_found(client: ThanoSQL):

--- a/tests/utils/table.py
+++ b/tests/utils/table.py
@@ -32,11 +32,9 @@ def create_table_template(
     version: Optional[str] = None,
     compatibility: Optional[str] = None,
 ) -> dict:
-    res = client.table.template.create(
+    return client.table.template.create(
         name=name, table_template=table, version=version, compatibility=compatibility
     )
-    res = client.table.template.get(name=name, version=version)
-    return res["table_templates"][0]
 
 
 def create_view(

--- a/thanosql/resources/_query.py
+++ b/thanosql/resources/_query.py
@@ -132,7 +132,7 @@ class QueryTemplateService(ThanoSQLService):
 
         self.query: QueryService = query
 
-    def parse_query_template_response(self, raw_response: dict):
+    def _parse_query_template_response(self, raw_response: dict):
         query_template_adapter = TypeAdapter(QueryTemplate)
         parsed_response = query_template_adapter.validate_python(
             raw_response["query_template"]
@@ -175,12 +175,12 @@ class QueryTemplateService(ThanoSQLService):
             method="post", path=path, query_params=query_params, payload=payload
         )
 
-        return self.parse_query_template_response(raw_response)
+        return self._parse_query_template_response(raw_response)
 
     def get(self, name: str) -> QueryTemplate:
         path = f"/{self.query.tag}/{self.tag}/{name}"
         raw_response = self.client._request(method="get", path=path)
-        return self.parse_query_template_response(raw_response)
+        return self._parse_query_template_response(raw_response)
 
     def update(
         self,
@@ -193,7 +193,7 @@ class QueryTemplateService(ThanoSQLService):
 
         raw_response = self.client._request(method="put", path=path, payload=payload)
 
-        return self.parse_query_template_response(raw_response)
+        return self._parse_query_template_response(raw_response)
 
     def delete(self, name: str) -> dict:
         path = f"/{self.query.tag}/{self.tag}/{name}"

--- a/thanosql/resources/_query.py
+++ b/thanosql/resources/_query.py
@@ -52,12 +52,12 @@ class QueryService(ThanoSQLService):
         table_name: Optional[str] = None,
         overwrite: Optional[bool] = None,
         max_results: Optional[int] = None,
-    ) -> Union[QueryLog, dict]:
+    ) -> QueryLog:
         try:
             query_type_enum = QueryType(query_type)
         except Exception as e:
             raise ThanoSQLValueError(str(e))
-        
+
         path = f"/{self.tag}/"
         query_params = self._create_input_dict(
             schema=schema,
@@ -77,12 +77,9 @@ class QueryService(ThanoSQLService):
             method="post", path=path, query_params=query_params, payload=payload
         )
 
-        if "query_id" in raw_response:
-            query_log_adapter = TypeAdapter(QueryLog)
-            parsed_response = query_log_adapter.validate_python(raw_response)
-            return parsed_response
-
-        return raw_response
+        query_log_adapter = TypeAdapter(QueryLog)
+        parsed_response = query_log_adapter.validate_python(raw_response)
+        return parsed_response
 
 
 class QueryLogService(ThanoSQLService):
@@ -108,16 +105,14 @@ class QueryLogService(ThanoSQLService):
             method="get", path=path, query_params=query_params
         )
 
-        if "query_logs" in raw_response:
-            query_logs_adapter = TypeAdapter(List[QueryLog])
-            parsed_response = {}
-            parsed_response["query_logs"] = query_logs_adapter.validate_python(
-                raw_response["query_logs"]
-            )
-            parsed_response["total"] = raw_response["total"]
-            return parsed_response
+        query_logs_adapter = TypeAdapter(List[QueryLog])
+        parsed_response = {}
+        parsed_response["query_logs"] = query_logs_adapter.validate_python(
+            raw_response["query_logs"]
+        )
+        parsed_response["total"] = raw_response["total"]
 
-        return raw_response
+        return parsed_response
 
 
 class QueryTemplate(BaseModel):
@@ -137,13 +132,20 @@ class QueryTemplateService(ThanoSQLService):
 
         self.query: QueryService = query
 
+    def parse_query_template_response(self, raw_response: dict):
+        query_template_adapter = TypeAdapter(QueryTemplate)
+        parsed_response = query_template_adapter.validate_python(
+            raw_response["query_template"]
+        )
+        return parsed_response
+
     def list(
         self,
         search: Optional[str] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         order_by: Optional[str] = None,
-    ) -> Union[List[QueryTemplate], dict]:
+    ) -> List[QueryTemplate]:
         path = f"/{self.query.tag}/{self.tag}"
         query_params = self._create_input_dict(
             search=search, offset=offset, limit=limit, order_by=order_by
@@ -153,21 +155,18 @@ class QueryTemplateService(ThanoSQLService):
             method="get", path=path, query_params=query_params
         )
 
-        if "query_templates" in raw_response:
-            query_templates_adapter = TypeAdapter(List[QueryTemplate])
-            parsed_response = query_templates_adapter.validate_python(
-                raw_response["query_templates"]
-            )
-            return parsed_response
-
-        return raw_response
+        query_templates_adapter = TypeAdapter(List[QueryTemplate])
+        parsed_response = query_templates_adapter.validate_python(
+            raw_response["query_templates"]
+        )
+        return parsed_response
 
     def create(
         self,
         name: Optional[str] = None,
         query: Optional[str] = None,
         dry_run: Optional[bool] = None,
-    ) -> Union[QueryTemplate, dict]:
+    ) -> QueryTemplate:
         path = f"/{self.query.tag}/{self.tag}"
         query_params = self._create_input_dict(dry_run=dry_run)
         payload = self._create_input_dict(name=name, query=query)
@@ -176,48 +175,25 @@ class QueryTemplateService(ThanoSQLService):
             method="post", path=path, query_params=query_params, payload=payload
         )
 
-        if "query_template" in raw_response:
-            query_template_adapter = TypeAdapter(QueryTemplate)
-            parsed_response = query_template_adapter.validate_python(
-                raw_response["query_template"]
-            )
-            return parsed_response
+        return self.parse_query_template_response(raw_response)
 
-        return raw_response
-
-    def get(self, name: str) -> Union[QueryTemplate, dict]:
+    def get(self, name: str) -> QueryTemplate:
         path = f"/{self.query.tag}/{self.tag}/{name}"
-
         raw_response = self.client._request(method="get", path=path)
-
-        if "query_template" in raw_response:
-            query_template_adapter = TypeAdapter(QueryTemplate)
-            parsed_response = query_template_adapter.validate_python(
-                raw_response["query_template"]
-            )
-            return parsed_response
-
-        return raw_response
+        return self.parse_query_template_response(raw_response)
 
     def update(
         self,
         current_name: str,
         new_name: Optional[str] = None,
         query: Optional[str] = None,
-    ) -> Union[QueryTemplate, dict]:
+    ) -> QueryTemplate:
         path = f"/{self.query.tag}/{self.tag}/{current_name}"
         payload = self._create_input_dict(name=new_name, query=query)
 
         raw_response = self.client._request(method="put", path=path, payload=payload)
 
-        if "query_template" in raw_response:
-            query_template_adapter = TypeAdapter(QueryTemplate)
-            parsed_response = query_template_adapter.validate_python(
-                raw_response["query_template"]
-            )
-            return parsed_response
-
-        return raw_response
+        return self.parse_query_template_response(raw_response)
 
     def delete(self, name: str) -> dict:
         path = f"/{self.query.tag}/{self.tag}/{name}"

--- a/thanosql/resources/_query.py
+++ b/thanosql/resources/_query.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 from datetime import datetime
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional
 
 from pydantic import TypeAdapter
 

--- a/thanosql/resources/_table.py
+++ b/thanosql/resources/_table.py
@@ -72,7 +72,7 @@ class TableService(ThanoSQLService):
 
         self.template: TableTemplateService = TableTemplateService(client)
 
-    def parse_table_response(self, raw_response: dict) -> Table:
+    def _parse_table_response(self, raw_response: dict) -> Table:
         table_adapter = TypeAdapter(Table)
         parsed_response = table_adapter.validate_python(raw_response["table"])
         parsed_response.service = self
@@ -108,7 +108,7 @@ class TableService(ThanoSQLService):
             method="get", path=path, query_params=query_params
         )
 
-        return self.parse_table_response(raw_response)
+        return self._parse_table_response(raw_response)
 
     def update(
         self, name: str, schema: Optional[str] = None, table: Optional[BaseTable] = None
@@ -121,7 +121,7 @@ class TableService(ThanoSQLService):
             method="put", path=path, query_params=query_params, payload=payload
         )
 
-        return self.parse_table_response(raw_response)
+        return self._parse_table_response(raw_response)
 
     def create(
         self,
@@ -137,7 +137,7 @@ class TableService(ThanoSQLService):
             method="post", path=path, query_params=query_params, payload=payload
         )
 
-        return self.parse_table_response(raw_response)
+        return self._parse_table_response(raw_response)
 
     def upload(
         self,
@@ -178,7 +178,7 @@ class TableService(ThanoSQLService):
             file=file,
         )
 
-        return self.parse_table_response(raw_response)
+        return self._parse_table_response(raw_response)
 
     def delete(self, name: str, schema: Optional[str] = None) -> dict:
         path = f"/{self.tag}/{name}"
@@ -320,4 +320,4 @@ class Table(BaseTable):
             method="post", path=path, query_params=query_params, payload=records
         )
 
-        return self.service.parse_table_response(raw_response)
+        return self.service._parse_table_response(raw_response)

--- a/thanosql/resources/_table.py
+++ b/thanosql/resources/_table.py
@@ -78,7 +78,7 @@ class TableService(ThanoSQLService):
         verbose: Optional[bool] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
-    ) -> Union[List[BaseTable], dict]:
+    ) -> Union[List[Table], dict]:
         path = f"/{self.tag}/"
         query_params = self._create_input_dict(
             schema=schema, verbose=verbose, offset=offset, limit=limit
@@ -89,8 +89,10 @@ class TableService(ThanoSQLService):
         )
 
         if "tables" in raw_response:
-            tables_adapter = TypeAdapter(List[BaseTable])
+            tables_adapter = TypeAdapter(List[Table])
             parsed_response = tables_adapter.validate_python(raw_response["tables"])
+            for table in parsed_response:
+                table.service = self
             return parsed_response
 
         return raw_response
@@ -113,7 +115,7 @@ class TableService(ThanoSQLService):
 
     def update(
         self, name: str, schema: Optional[str] = None, table: Optional[BaseTable] = None
-    ) -> BaseTable:
+    ) -> Table:
         path = f"/{self.tag}/{name}"
         query_params = self._create_input_dict(schema=schema)
         payload = self._create_input_dict(table=table)
@@ -123,10 +125,11 @@ class TableService(ThanoSQLService):
         )
         
         if "table" in raw_response:
-            table_adapter = TypeAdapter(BaseTable)
+            table_adapter = TypeAdapter(Table)
             parsed_response = table_adapter.validate_python(
                 raw_response["table"]
             )
+            parsed_response.service = self
             return parsed_response
 
         return raw_response
@@ -136,7 +139,7 @@ class TableService(ThanoSQLService):
         name: str,
         schema: Optional[str] = None,
         table: Optional[TableObject] = None,
-    ) -> BaseTable:
+    ) -> Table:
         path = f"/{self.tag}/{name}"
         query_params = self._create_input_dict(schema=schema)
         payload = self._create_input_dict(table=table)
@@ -146,10 +149,11 @@ class TableService(ThanoSQLService):
         )
         
         if "table" in raw_response:
-            table_adapter = TypeAdapter(BaseTable)
+            table_adapter = TypeAdapter(Table)
             parsed_response = table_adapter.validate_python(
                 raw_response["table"]
             )
+            parsed_response.service = self
             return parsed_response
 
         return raw_response
@@ -161,7 +165,7 @@ class TableService(ThanoSQLService):
         schema: Optional[str] = None,
         table: Optional[TableObject] = None,
         if_exists: Optional[str] = None,
-    ) -> BaseTable:
+    ) -> Table:
         path = f"/{self.tag}/{name}/upload/"
 
         file_extension = Path(file).suffix.lower()
@@ -194,10 +198,11 @@ class TableService(ThanoSQLService):
         )
         
         if "table" in raw_response:
-            table_adapter = TypeAdapter(BaseTable)
+            table_adapter = TypeAdapter(Table)
             parsed_response = table_adapter.validate_python(
                 raw_response["table"]
             )
+            parsed_response.service = self
             return parsed_response
 
         return raw_response

--- a/thanosql/resources/_table.py
+++ b/thanosql/resources/_table.py
@@ -113,28 +113,46 @@ class TableService(ThanoSQLService):
 
     def update(
         self, name: str, schema: Optional[str] = None, table: Optional[BaseTable] = None
-    ) -> dict:
+    ) -> BaseTable:
         path = f"/{self.tag}/{name}"
         query_params = self._create_input_dict(schema=schema)
         payload = self._create_input_dict(table=table)
 
-        return self.client._request(
+        raw_response = self.client._request(
             method="put", path=path, query_params=query_params, payload=payload
         )
+        
+        if "table" in raw_response:
+            table_adapter = TypeAdapter(BaseTable)
+            parsed_response = table_adapter.validate_python(
+                raw_response["table"]
+            )
+            return parsed_response
+
+        return raw_response
 
     def create(
         self,
         name: str,
         schema: Optional[str] = None,
         table: Optional[TableObject] = None,
-    ) -> dict:
+    ) -> BaseTable:
         path = f"/{self.tag}/{name}"
         query_params = self._create_input_dict(schema=schema)
         payload = self._create_input_dict(table=table)
 
-        return self.client._request(
+        raw_response = self.client._request(
             method="post", path=path, query_params=query_params, payload=payload
         )
+        
+        if "table" in raw_response:
+            table_adapter = TypeAdapter(BaseTable)
+            parsed_response = table_adapter.validate_python(
+                raw_response["table"]
+            )
+            return parsed_response
+
+        return raw_response
 
     def upload(
         self,
@@ -143,7 +161,7 @@ class TableService(ThanoSQLService):
         schema: Optional[str] = None,
         table: Optional[TableObject] = None,
         if_exists: Optional[str] = None,
-    ) -> dict:
+    ) -> BaseTable:
         path = f"/{self.tag}/{name}/upload/"
 
         file_extension = Path(file).suffix.lower()
@@ -167,13 +185,22 @@ class TableService(ThanoSQLService):
         query_params = self._create_input_dict(schema=schema, if_exists=if_exists)
         payload = self._create_input_dict(table=table)
 
-        return self.client._request(
+        raw_response = self.client._request(
             method="post",
             path=path,
             query_params=query_params,
             payload=payload,
             file=file,
         )
+        
+        if "table" in raw_response:
+            table_adapter = TypeAdapter(BaseTable)
+            parsed_response = table_adapter.validate_python(
+                raw_response["table"]
+            )
+            return parsed_response
+
+        return raw_response
 
     def delete(self, name: str, schema: Optional[str] = None) -> dict:
         path = f"/{self.tag}/{name}"
@@ -247,7 +274,7 @@ class TableTemplateService(ThanoSQLService):
         table_template: TableObject,
         version: Optional[str] = None,
         compatibility: Optional[str] = None,
-    ) -> dict:
+    ) -> TableTemplate:
         path = f"/{self.tag}/{name}"
         payload = self._create_input_dict(
             table_template=vars(table_template),
@@ -255,7 +282,16 @@ class TableTemplateService(ThanoSQLService):
             compatibility=compatibility,
         )
 
-        return self.client._request(method="post", path=path, payload=payload)
+        raw_response = self.client._request(method="post", path=path, payload=payload)
+
+        if "table_template" in raw_response:
+            table_template_adapter = TypeAdapter(TableTemplate)
+            parsed_response = table_template_adapter.validate_python(
+                raw_response["table_template"]
+            )
+            return parsed_response
+
+        return raw_response
 
     def delete(self, name: str, version: Optional[str] = None) -> dict:
         path = f"/{self.tag}/{name}"

--- a/thanosql/resources/_view.py
+++ b/thanosql/resources/_view.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional
 
 from pydantic import Field, TypeAdapter
 
@@ -29,7 +29,7 @@ class ViewService(ThanoSQLService):
         verbose: Optional[bool] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
-    ) -> Union[List[View], dict]:
+    ) -> List[View]:
         path = f"/{self.tag}/"
         query_params = self._create_input_dict(
             schema=schema,
@@ -42,14 +42,11 @@ class ViewService(ThanoSQLService):
             method="get", path=path, query_params=query_params
         )
 
-        if "views" in raw_response:
-            views_adapter = TypeAdapter(List[View])
-            parsed_response = views_adapter.validate_python(raw_response["views"])
-            return parsed_response
+        views_adapter = TypeAdapter(List[View])
+        parsed_response = views_adapter.validate_python(raw_response["views"])
+        return parsed_response
 
-        return raw_response
-
-    def get(self, name: str, schema: Optional[str] = None) -> Union[View, dict]:
+    def get(self, name: str, schema: Optional[str] = None) -> View:
         path = f"/{self.tag}/{name}"
         query_params = self._create_input_dict(schema=schema)
 
@@ -57,12 +54,9 @@ class ViewService(ThanoSQLService):
             method="get", path=path, query_params=query_params
         )
 
-        if "view" in raw_response:
-            view_adapter = TypeAdapter(View)
-            parsed_response = view_adapter.validate_python(raw_response["view"])
-            return parsed_response
-
-        return raw_response
+        view_adapter = TypeAdapter(View)
+        parsed_response = view_adapter.validate_python(raw_response["view"])
+        return parsed_response
 
     def delete(self, name: str, schema: Optional[str] = None) -> dict:
         path = f"/{self.tag}/{name}"


### PR DESCRIPTION
Clickup task ID: CU-86ep0n6b0

This PR is designed to match the recent change in endpoint responses for engine v1.5.2 (https://github.com/smartmind-team/thanosql-engine/pull/332)

- Create, update, and upload table now returns the recently created/updated table object (previously: just a message and table name)
- Create table template now returns the recently created table template object (previously: just a message and table template name)