### PR TITLE
fix: add schema to upload and delete file input

### DIFF
--- a/thanosql/resources/_file.py
+++ b/thanosql/resources/_file.py
@@ -27,11 +27,16 @@ class FileService(ThanoSQLService):
         db_commit: Optional[bool] = None,
         table: Optional[str] = None,
         column: Optional[str] = None,
+        schema: Optional[str] = None,
         dir: Optional[str] = None,
     ) -> dict:
         api_path = f"/{self.tag}/"
         query_params = self._create_input_dict(
-            db_commit=db_commit, table_name=table, column_name=column, dir=dir
+            db_commit=db_commit,
+            table_name=table,
+            column_name=column,
+            schema=schema,
+            dir=dir,
         )
 
         return self.client._request(
@@ -44,10 +49,15 @@ class FileService(ThanoSQLService):
         db_commit: Optional[bool] = None,
         table: Optional[str] = None,
         column: Optional[str] = None,
+        schema: Optional[str] = None,
     ) -> dict:
         api_path = f"/{self.tag}/"
         query_params = self._create_input_dict(
-            file_path=path, db_commit=db_commit, table_name=table, column_name=column
+            file_path=path,
+            db_commit=db_commit,
+            table_name=table,
+            column_name=column,
+            schema=schema,
         )
 
         return self.client._request(


### PR DESCRIPTION
- Match recent version of engine: allow upload and delete file to access tables outside the "public" schema