### PR TITLE
feat: better HTTP response handler in ThanoSQLBaseClient._request()

### DIFF
--- a/thanosql/_base_client.py
+++ b/thanosql/_base_client.py
@@ -125,31 +125,17 @@ class ThanoSQLBaseClient:
                     message = response_json["error"].get("message", message)
 
                 if code in {400, 405, 422}:
-                    raise thanosql_error.ThanoSQLValueError(
-                        message=f"Invalid input: {message}"
-                    )
+                    raise thanosql_error.ThanoSQLValueError(message=message)
                 elif code in {401, 403}:
-                    raise thanosql_error.ThanoSQLPermissionError(
-                        message=f"Operation not permitted: {message}"
-                    )
+                    raise thanosql_error.ThanoSQLPermissionError(message=message)
                 elif code == 404:
-                    raise thanosql_error.ThanoSQLNotFoundError(
-                        message=f"Not found: {message}"
-                    )
+                    raise thanosql_error.ThanoSQLNotFoundError(message=message)
                 elif code == 409:
-                    raise thanosql_error.ThanoSQLAlreadyExistsError(
-                        message=f"Object already exists: {message}"
-                    )
-                elif code == 413:
-                    raise thanosql_error.ThanoSQLConnectionError(
-                        message=f"Entity size too large: {message}"
-                    )
-                elif code == 500:
-                    raise thanosql_error.ThanoSQLInternalError(
-                        message=f"Internal server error: {message}"
-                    )
+                    raise thanosql_error.ThanoSQLAlreadyExistsError(message=message)
+                # includes 413 and 500, among many others
+                # will show up as ThanoSQLInternalError with the message from raise_for_status
                 else:
-                    raise thanosql_error.ThanoSQLInternalError(message=message)
+                    response.raise_for_status()
 
             if stream:
                 filename = response.headers.get(

--- a/thanosql/_base_client.py
+++ b/thanosql/_base_client.py
@@ -125,14 +125,30 @@ class ThanoSQLBaseClient:
                     message = response_json["error"].get("message", message)
 
                 if code in {400, 405, 422}:
-                    raise thanosql_error.ThanoSQLValueError(message=message)
+                    raise thanosql_error.ThanoSQLValueError(
+                        message=f"Invalid input: {message}"
+                    )
                 elif code in {401, 403}:
-                    raise thanosql_error.ThanoSQLPermissionError(message=message)
+                    raise thanosql_error.ThanoSQLPermissionError(
+                        message=f"Operation not permitted: {message}"
+                    )
                 elif code == 404:
-                    raise thanosql_error.ThanoSQLNotFoundError(message=message)
+                    raise thanosql_error.ThanoSQLNotFoundError(
+                        message=f"Not found: {message}"
+                    )
                 elif code == 409:
-                    raise thanosql_error.ThanoSQLAlreadyExistsError(message=message)
+                    raise thanosql_error.ThanoSQLAlreadyExistsError(
+                        message=f"Object already exists: {message}"
+                    )
+                elif code == 413:
+                    raise thanosql_error.ThanoSQLConnectionError(
+                        message=f"Entity size too large: {message}"
+                    )
                 elif code == 500:
+                    raise thanosql_error.ThanoSQLInternalError(
+                        message=f"Internal server error: {message}"
+                    )
+                else:
                     raise thanosql_error.ThanoSQLInternalError(message=message)
 
             if stream:


### PR DESCRIPTION
CU task ID: CU-86ep7agt4

- Add short introduction to error messages for clarity -> reverted
- Catch 413 error -> this is difficult to replicate in dev since it's an NGINX error, and dev doesn't really have a size limit -> solved, can be replicated with prod engine (and dev SDK)

Samples:
![Screenshot 2024-04-25 at 3 58 10 PM](https://github.com/smartmind-team/thanosql-sdk-python/assets/56180830/51eaf5bb-fc3f-4bcd-9307-05d87775b561)
![Screenshot 2024-04-25 at 3 59 03 PM](https://github.com/smartmind-team/thanosql-sdk-python/assets/56180830/351e17ff-6371-4796-b92c-a4702aa3a5ab)
![Screenshot 2024-04-25 at 4 01 37 PM](https://github.com/smartmind-team/thanosql-sdk-python/assets/56180830/c6dfa467-0e29-4181-81eb-28c31b6fc5c6)
![Screenshot 2024-04-25 at 4 03 18 PM](https://github.com/smartmind-team/thanosql-sdk-python/assets/56180830/64b73535-c94f-4de7-9ad3-5e55d868692d)
