### PR TITLE
Feat/on conflict

### DIFF
--- a/thanosql/resources/_file.py
+++ b/thanosql/resources/_file.py
@@ -72,10 +72,12 @@ class FileService(ThanoSQLService):
 
         Returns
         -------
-        Depending on option:
-        - default (None): Returns a Content Pydantic object containing
-            information on the target path
-        - download: Downloads the requested file and returns nothing
+        Content | None
+            Depending on option:
+
+            - default (None): Returns a Content Pydantic object containing \
+                information on the target path
+            - download: Downloads the requested file and returns nothing
 
         Raises
         ------

--- a/thanosql/resources/_query.py
+++ b/thanosql/resources/_query.py
@@ -127,6 +127,7 @@ class QueryService(ThanoSQLService):
         ------
         ThanoSQLValueError
             - If invalid input combination is provided; that is:
+
                 - query, template_id, and template_name are all empty, or
                 - more than one of query, template_id, and template_name are non-empty
             - If a value other than "thanosql" or "psql" is provided as query_type.
@@ -294,6 +295,7 @@ class QueryTemplateService(ThanoSQLService):
             lists up to 100 results per call. Must range between 0 to 100.
         order_by : str, optional
             How to order the results. There are only three possible values:
+
             - recent: based on the date of creation, from most recent to oldest
             - name_asc: based on the name of the template, from A to Z
             - name_desc: based on the name of the template, from Z to A

--- a/thanosql/resources/_table.py
+++ b/thanosql/resources/_table.py
@@ -195,18 +195,18 @@ class TableService(ThanoSQLService):
             updated. Any attribute of BaseTable can be modified, and if left
             unset, the current value will be maintained after update.
             The attributes are as follows:
-            - name: new name to rename the table to
-            - schema: new schema to move the table to
-            - columns: new columns of the updated table. All new columns
-                must be in this object, including columns that already exist
-                in the original table. If this attribute is set but some
-                original columns are not included, they will be removed from
-                the table.
-            - constraints: new constraints of the updated table. All new
-                constraints must be in this object, including constraints
-                that already exist in the original table. If this attribute is
-                set but some original constraints are not included, they will
-                be removed from the table.
+                - name: new name to rename the table to
+                - schema: new schema to move the table to
+                - columns: new columns of the updated table. All new columns \
+                    must be in this object, including columns that already exist \
+                    in the original table. If this attribute is set but some \
+                    original columns are not included, they will be removed from \
+                    the table.
+                - constraints: new constraints of the updated table. All new \
+                    constraints must be in this object, including constraints \
+                    that already exist in the original table. If this attribute is \
+                    set but some original constraints are not included, they will \
+                    be removed from the table.
 
         Returns
         -------
@@ -311,11 +311,11 @@ class TableService(ThanoSQLService):
         if_exists : str, default "fail"
             What to do if table of the same name already exists. There are only
             three available values:
-            - fail: fails (throws an error) if the same table exists
-            - append: appends records into an existing table (columns must match
-                in order to not make an error)
-            - replace: deletes existing table and creates a new one with the
-                given name
+                - fail: fails (throws an error) if the same table exists
+                - append: appends records into an existing table (columns must match \
+                    in order to not make an error)
+                - replace: deletes existing table and creates a new one with the \
+                    given name
 
         Returns
         -------
@@ -533,10 +533,10 @@ class Table(BaseTable):
         on_conflict : str, default "fail"
             What to do when conflict(s) due to unique constraint violation happen(s).
             There are only two available values:
-            - fail: fails (throws an error) if any of the record violates the target
-                table's unique constraint(s)
-            - skip: skips record(s) that violate(s) unique constraint(s) and insert
-                the rest
+                - fail: fails (throws an error) if any of the record violates the target \
+                    table's unique constraint(s)
+                - skip: skips record(s) that violate(s) unique constraint(s) and insert \
+                    the rest
 
         Returns
         -------
@@ -603,6 +603,7 @@ class TableTemplateService(ThanoSQLService):
             contain. If not set, all table templates are returned by default.
         order_by : str, optional
             How to order the results. There are only three possible values:
+
             - recent: based on the date of creation, from most recent to oldest
             - name_asc: based on the name of the template, from A to Z
             - name_desc: based on the name of the template, from Z to A


### PR DESCRIPTION
- Add parameter on_conflict when inserting records, allowing users to specify what to do when insertion results in unique constraint violation. This is to support this feature -> https://github.com/smartmind-team/thanosql-api/pull/14
- Update docstring and fix docstring with bullet points that are rendered incorrectly

Note: There seems to be some bugs in Sphinx. In most cases, both of these should give the same result:

Option 1
```
Lorem ipsum
     - One
     - Two
     - Three
```

Option 2
```
Lorem ipsum

- One
- Two
- Three
```

During testing, it so happened that sometimes "Lorem ipsum" is printed in bold if we use Option 1, but this does not happen with Option 2. In a few cases, Option 1 and 2 must be used simultaneously to get the result we want. There is really no way of knowing what would happen unless we build and check the resulting index.html in browser. Because of this, Option 1 and 2 are both used inconsistently in this PR -- Option 1 is prioritized due to better aesthetics (in my opinion), but if rendering mistakes happen, Option 2 is used instead (or alongside).